### PR TITLE
add path setting for custom css file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ This extension contributes the following settings:
 
     Chrome executable path, which is used for Puppeteer export. Leaving it empty means the path will be found automatically `(only for windows)`.
 
+* `markdown-preview-showdown.cssPath`:
+
+    A relative (./default.css) or absolute path (x:/styles/default.css) to a css file containing custom styles. For example, the following style will allow font ligatures to display in the preview or exported versions where `class="fira"` is used:
+
+```css
+      .fira {
+      font-family: 'Fira Code', monospace;
+      font-variant-ligatures: contextual;
+      font-feature-settings: "calt" 1, "liga" 1, "clig" 1;
+      line-height: 1.0;
+      margin: 0 !important;
+      padding: 0  !important;
+      border: none !important;
+      display: inline !important;
+      background: none !important;
+      vertical-align: baseline;
+    }
+```
+
 ## Keybindings
 
 |OS|Key|Command|

--- a/package.json
+++ b/package.json
@@ -194,6 +194,11 @@
           "default": "",
           "type": "string",
           "scope": "machine"
+        },
+        "markdown-preview-showdown.cssPath": {
+          "description": "%mdps.cssPath%",
+          "default": [],
+          "scope": "machine"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -197,7 +197,8 @@
         },
         "markdown-preview-showdown.cssPath": {
           "description": "%mdps.cssPath%",
-          "default": [],
+           "type": "string",
+          "default": "",
           "scope": "machine"
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-preview-showdown",
   "displayName": "%mdps.displayname%",
   "description": "%mdps.description%",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "publisher": "jhuix",
   "author": {
     "name": "jhuix"

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,5 +19,6 @@
   "mdps.plantuml.website": "When the setting item of plantumlrendermode is mode \"remote\", the remote rendering website to be set, default web site is \"www.plantuml.com/plantuml\".",
   "mdps.puppeteer.useCore": "If set to true, then locally installed puppeteer-core will be required. Otherwise, the puppeteer globally installed by `npm install -g puppeteer` will be required.",
   "mdps.puppeteer.waitForTimeout": "Puppeteer waits for a certain timeout in milliseconds before the document export.",
-  "mdps.puppeteer.chromePath": "Chrome executable path, which is used for Puppeteer export. Leaving it empty means the path will be found automatically."
+  "mdps.puppeteer.chromePath": "Chrome executable path, which is used for Puppeteer export. Leaving it empty means the path will be found automatically.",
+  "mdps.cssPath": "Path to custom styles for preview and export. May be relative or absolute."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -19,5 +19,6 @@
   "mdps.plantuml.website": "当设置项plantumlRenderMode为模式\"remote\"时，需设置的远程渲染网址，默认网址为\"www.plantuml.com/plantuml\"。",
   "mdps.puppeteer.useCore": "若该值为真，则使用当前插件下安装使用puppeteer-core包（插件自身会自动安装）；否则需要使用脚本`npm install -g puppeteer`手动来全局安装使用puppeteer包并。",
   "mdps.puppeteer.waitForTimeout": "在导出文件时，Puppeteer包执行导出过程运行相关进程的等待时间，单位毫秒，默认值为0表示无限等待直到自动完成导出。",
-  "mdps.puppeteer.chromePath": "使用Puppeteer包导出文件时，需设置的Chrome浏览器执行文件（chrome.exe）的文件绝对路径；该值为空时，则表示导出时会自动寻找Chrome浏览器的安装路径。"
+  "mdps.puppeteer.chromePath": "使用Puppeteer包导出文件时，需设置的Chrome浏览器执行文件（chrome.exe）的文件绝对路径；该值为空时，则表示导出时会自动寻找Chrome浏览器的安装路径。",
+  "mdps.cssPath": "预览和导出自定义样式的路径，可以是相对路径或绝对路径。"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export class PreviewConfig {
     return typeof data === 'undefined' ? defaultValue : data;
   }
 
+  public cssPath: string;
   public locale: string;
   public autoPreview: boolean;
   public fontSize: number;
@@ -49,7 +50,8 @@ export class PreviewConfig {
   public constructor(context: vscode.ExtensionContext) {
     this.printBackground = false;
     this.locale = 'en';
-    // Get gurrent localization id, default 'en'.
+    this.cssPath = '';
+    // Get current localization id, default 'en'.
     if (typeof process.env.VSCODE_NLS_CONFIG === 'string') {
       const vscodeOptions = JSON.parse(process.env.VSCODE_NLS_CONFIG);
       if (vscodeOptions.hasOwnProperty('locale') && vscodeOptions.locale) {
@@ -61,6 +63,7 @@ export class PreviewConfig {
       const config = vscode.workspace.getConfiguration(PreviewConfig.packageName);
 
       this.autoPreview = PreviewConfig.getData(config.get('autoPreview'), true);
+      this.cssPath = PreviewConfig.getData(config.get('cssPath'), '');
       this.scrollSync = PreviewConfig.getData(config.get('scrollSync'), true);
       this.fontSize = PreviewConfig.getData(config.get('fontSize'), Math.pow(8, 5));
       this.mermaidTheme = PreviewConfig.getData(config.get('mermaid.theme'), 'default');
@@ -143,6 +146,7 @@ export class PreviewConfig {
       }
     } else {
       this.autoPreview = false;
+      this.cssPath = '';
       this.fontSize = PreviewConfig.defaultFontSize;
       this.scrollSync = true;
       this.flavor = 'github';


### PR DESCRIPTION
The previewer and exports do not handle some circumstances well, for example if using a font with ligatures (e.g. Fira Code) these are not rendered. It would be very useful to be able to inject some styling  to handle these cases and also allow classes that could be used for coloring, emphasis etc.
This Pull Request includes a new setting for cssPath. If this is provided and the file is found, the css will be used in the Previewer and in the exports.
For example, the following code can support ligatures:
```css
.fira {
    font-family: 'Fira Code', monospace;
    font-variant-ligatures: contextual;
    font-feature-settings: "calt" 1, "liga" 1, "clig" 1;
    line-height: 1.0;
    margin: 0 !important;
    padding: 0  !important;
    border: none !important;
    display: inline !important;
    background: none !important;
    vertical-align: baseline;
}
```